### PR TITLE
builder sa name mismatch error

### DIFF
--- a/.github/workflows/v2_srv_builder_execute.yaml
+++ b/.github/workflows/v2_srv_builder_execute.yaml
@@ -188,7 +188,7 @@ jobs:
           #Actions
           pulumi --non-interactive stack select ${stack_name} --create
           pulumi --non-interactive config set project ${{ inputs.PROJECT_ID }}
-          pulumi --non-interactive config set builder cicd-service-account@${{ inputs.PROJECT_ID }}.iam.gserviceaccount.com
+          pulumi --non-interactive config set builder cicd-sa@${{ inputs.PROJECT_ID }}.iam.gserviceaccount.com
           pulumi --non-interactive refresh --yes
           pulumi --non-interactive preview --policy-pack '/home/runner/work/${{ inputs.GITHUB_NAME }}/${{ inputs.GITHUB_NAME }}/my-tools/policypack'
           # Run the local policy pack if it exists

--- a/.github/workflows/v2_stg_builder_execute.yaml
+++ b/.github/workflows/v2_stg_builder_execute.yaml
@@ -208,7 +208,7 @@ jobs:
             pulumi --non-interactive login gs://pulumi-state-${{ inputs.PROJECT_ID }}/${DIR}
             pulumi --non-interactive stack select ${stack_name} --create
             pulumi --non-interactive config set project ${{ inputs.PROJECT_ID }}
-            pulumi --non-interactive config set builder cicd-service-account@${{ inputs.PROJECT_ID }}.iam.gserviceaccount.com
+            pulumi --non-interactive config set builder cicd-sa@${{ inputs.PROJECT_ID }}.iam.gserviceaccount.com
             pulumi --non-interactive refresh --yes
             if [[ ${current_date} < $staging_expiry_date ]]
             then


### PR DESCRIPTION
@dongqiaoyang ,

Found the name mismatch for the value set to pulumi builder SA.

See the below details from the recent build log.

=================================
Diagnostics:
  pulumi:pulumi:Stack (resources_creation-bdingiri):
    error: update failed
 
  gcp:workflows:Workflow (wf-srvls-spark-job-cust):
    error: 1 error occurred:
    	* Error creating Workflow: googleapi: Error 400: service account to be used as workflow identity not found: projects/-/serviceAccounts/cicd-service-account@bi-stg-syrax-pr-d24428.iam.gserviceaccount.com